### PR TITLE
chore: Run build during tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           cmd: install
       - uses: borales/actions-yarn@v2.1.0
         with:
-          cmd: build:codesandbox
+          cmd: build
       - uses: borales/actions-yarn@v2.1.0
         with:
           cmd: test


### PR DESCRIPTION
Changed build command to use publish command in place of codesandbox, 
this will allow the PRs to fail the build process if linting rules fail