### PR TITLE
RLZ-2874 fix a typo to flex-basis of business valuation

### DIFF
--- a/packages/components/src/elements/business-valuations/business-valuations.scss
+++ b/packages/components/src/elements/business-valuations/business-valuations.scss
@@ -39,7 +39,7 @@
   align-items: flex-start;
   padding-bottom: 8px;
   overflow: visible;
-  flex-basis: 25%;
+  flex-basis: 50%;
   min-width: 240px;
 
   .rv-valuation-title {


### PR DESCRIPTION
fix a typo of flex-basis.

Before (business valuation with flex-basis 25%):
<img width="1641" alt="Screenshot 2023-05-11 at 3 13 05 PM" src="https://github.com/railz-ai/railz-visualizations/assets/19851927/4e9967d2-e717-45f8-b5a5-605b7e64e1d4">

After (business valuation with flex-basis 50%):
<img width="1641" alt="Screenshot 2023-05-11 at 3 12 53 PM" src="https://github.com/railz-ai/railz-visualizations/assets/19851927/fb4e9bc5-54e0-4d02-be76-182f61957b85">
