### PR TITLE
bugfix/RLZ-2928 fix business valuations no data

### DIFF
--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -62,10 +62,15 @@ app.get('/authenticate', (request, response) => {
       response.status(200).json({ success: true, access_token: res.data.access_token });
     })
     .catch((error) => {
-      console.error(error);
-      response.status(401).json({
+      const message = Array.isArray(error?.response?.data?.error?.message)
+        ? error?.response?.data?.error?.message[0]
+        : error;
+      const status = error?.response?.status ? error.response.status : 401;
+      console.error(error?.response?.data, error?.response?.status);
+
+      response.status(status).json({
         success: false,
-        error: 'Authentication with Railz API Failed',
+        error: message || 'Authentication with Railz API Failed',
       });
     });
 });


### PR DESCRIPTION
This PR implements this ticket: https://railzz.atlassian.net/browse/RLZ-2928

The idea is that for partial results (where some of the valuations are empty) we show N/A instead of a completely empty box.
And when all the results are empty, we show the 204 error code (that we show normally).

I also refactored a bit of the component, removing unused code, and extracting components away. 
And a small error handling fix for the node server, to pass the errors and log them up better.

Some screenshots of it working.

<img width="1136" alt="Screenshot 2023-06-02 at 16 34 37" src="https://github.com/railz-ai/railz-visualizations/assets/10502605/e1def8f7-6fcf-4049-a88f-78f4f2041983">
<img width="601" alt="Screenshot 2023-06-02 at 16 28 59" src="https://github.com/railz-ai/railz-visualizations/assets/10502605/036b0fe9-1d68-4bcb-803c-1db8dc3c6010">
