### PR TITLE
fix: RLZ-2928 show N-A for partial results and small refactor

### DIFF
--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -62,10 +62,15 @@ app.get('/authenticate', (request, response) => {
       response.status(200).json({ success: true, access_token: res.data.access_token });
     })
     .catch((error) => {
-      console.error(error);
-      response.status(401).json({
+      const message = Array.isArray(error?.response?.data?.error?.message)
+        ? error?.response?.data?.error?.message[0]
+        : error;
+      const status = error?.response?.status ? error.response.status : 401;
+      console.error(error?.response?.data, error?.response?.status);
+
+      response.status(status).json({
         success: false,
-        error: 'Authentication with Railz API Failed',
+        error: message || 'Authentication with Railz API Failed',
       });
     });
 });


### PR DESCRIPTION
This PR implements this ticket: https://railzz.atlassian.net/browse/RLZ-2928

The idea is that for partial results (where some of the valuations are empty) we show N/A instead of a empty box.
And when all the results are empty, we show the 204 error code (that we show normally).

I also refactored a bit of the component, removing unused code, and extracting components away.
And a small error handling fix for the node server, to pass the errors and log them up better.

Some screenshots of it working.
![image](https://github.com/railz-ai/railz-visualizations/assets/10502605/8ef9b108-d456-411c-a4c9-a6f505ecaef4)
![image](https://github.com/railz-ai/railz-visualizations/assets/10502605/207f21fd-4b29-48ea-a7ce-66bf65c96a56)
