### PR TITLE
fix:RLZ-2928-show_N-A_only_for_invalid_values

### DIFF
--- a/packages/components/src/elements/business-valuations/business-valuations.tsx
+++ b/packages/components/src/elements/business-valuations/business-valuations.tsx
@@ -55,7 +55,7 @@ const ValuationSection = (
   percentage: number,
   options: RVOptions,
 ): HTMLElement => {
-  const parsedValue = isNil(percentage) ? 'N/A' : formatCurrencyValue(Math.round(value), 0);
+  const parsedValue = formatCurrencyValue(Math.round(value), 0, 'N/A');
   const parsedPercentage =
     isNil(percentage) || isNaN(percentage) || Math.abs(percentage) === Infinity
       ? null

--- a/packages/components/src/helpers/utils.ts
+++ b/packages/components/src/helpers/utils.ts
@@ -71,16 +71,14 @@ export const formatNumber = (number: number | string, decimals = 2, minimum = 0)
   return '';
 };
 
-export const formatCurrencyValue = (value: number, decimals = 2): string => {
-  const formatCurrencyNumber = (number: number, decimals = 2): string => {
-    if (!isNil(number)) {
-      return numbro(Number(number)).format(`0,000.${'0'.repeat(decimals)}`);
-    }
-    return '';
-  };
-  return formatCurrencyNumber(value as number, decimals) === ''
-    ? '-'
-    : '$' + formatCurrencyNumber(value as number, decimals);
+const formatCurrencyNumber = (value: number, decimals = 2): string => {
+  if (isNil(value)) return '';
+  return numbro(Number(value)).format(`0,000.${'0'.repeat(decimals)}`);
+};
+
+export const formatCurrencyValue = (value: number, decimals = 2, fallbackValue = '-'): string => {
+  const formattedValue = formatCurrencyNumber(value, decimals);
+  return ['', 'NaN'].includes(formattedValue) ? fallbackValue : '$' + formattedValue;
 };
 
 /**


### PR DESCRIPTION
This PR addresses this comment: https://railzz.atlassian.net/browse/RLZ-2928?focusedCommentId=30302

Basically, I was using the wrong value to define if it should be showing N/A or the value (I was using the percentage, I should have used the value).