### PR TITLE
RLZ-3159 Fix Mobile View for Income Statements

### DIFF
--- a/packages/components/src/elements/income-statements/income-statements.scss
+++ b/packages/components/src/elements/income-statements/income-statements.scss
@@ -39,6 +39,10 @@
   display: flex;
   margin-left: -10px;
   flex-direction: row;
+  @media screen and (max-width: 600px) {
+    flex-direction: column;
+    height: calc(90% - 5px);
+  }
 }
 
 .rv-income-statements-chart-box {
@@ -49,6 +53,11 @@
   align-items: flex-start;
   flex-direction: column;
   justify-content: center;
+  @media screen and (max-width: 600px) {
+    position: relative;
+    top: -20px;
+    align-items: center;
+  }
 }
 
 .rv-income-statements-chart-text {

--- a/packages/components/src/elements/income-statements/income-statements.scss
+++ b/packages/components/src/elements/income-statements/income-statements.scss
@@ -41,14 +41,23 @@
   flex-direction: row;
   @media screen and (max-width: 600px) {
     flex-direction: column;
-    height: calc(90% - 5px);
+    height: calc(90% + 5px);
+  }
+}
+
+.rv-income-statements-chart-container #rv-income-statements-chart {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  flex-shrink: 1;
+  height: 100%;
+  @media screen and (max-width: 600px) {
+    height: 90%;
   }
 }
 
 .rv-income-statements-chart-box {
   visibility: inherit;
-  -webkit-font-smoothing: antialiased;
-  color: rgb(0 0 0 / 87%);
   display: flex;
   align-items: flex-start;
   flex-direction: column;
@@ -58,6 +67,15 @@
     top: -20px;
     align-items: center;
   }
+}
+
+.rv-income-statements-chart-box-content {
+  -webkit-font-smoothing: antialiased;
+  color: rgb(0 0 0 / 87%);
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  justify-content: left;
 }
 
 .rv-income-statements-chart-text {

--- a/packages/components/src/elements/income-statements/test/income-statements.spec.tsx
+++ b/packages/components/src/elements/income-statements/test/income-statements.spec.tsx
@@ -97,9 +97,11 @@ describe('railz-income-statements', () => {
           <div class="rv-income-statements-chart-container">
             <div id="rv-income-statements-chart"></div>
             <div class="rv-income-statements-chart-box">
-              <p class="rv-income-statements-chart-text">
-                $
-              </p>
+              <div class="rv-income-statements-chart-box-content">
+                <p class="rv-income-statements-chart-text">
+                  $
+                </p>
+                </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<img width="428" alt="Screenshot Railz Dashboard 2024-01-25 22-15-40" src="https://github.com/railz-ai/railz-visualizations/assets/10502605/077e9d42-55dd-410d-9a07-a3ada23ffa49">
<img width="511" alt="Screenshot React App 2024-01-25 22-16-01" src="https://github.com/railz-ai/railz-visualizations/assets/10502605/82d1b70c-4ac6-4abd-9946-7abe9c219ba1">

This was super hard.
